### PR TITLE
Fix initialization bugs and task storage

### DIFF
--- a/lua/periscope/init.lua
+++ b/lua/periscope/init.lua
@@ -118,11 +118,11 @@ local function setup_user_commands()
 		end)
 	end, {})
 end
-function setup(enabled)
-	enabled = enabled
-	nvimtree().set_filter_enabled(enabled)
-	setup_auto_commands();
-	setup_user_commands();
+function setup(start_enabled)
+        enabled = start_enabled
+        nvimtree().set_filter_enabled(start_enabled)
+        setup_auto_commands();
+        setup_user_commands();
 end
 
 --setup(true)

--- a/lua/periscope/model.lua
+++ b/lua/periscope/model.lua
@@ -112,9 +112,9 @@ end
 
 -- Appends a task to the workspace
 function append_task(task)
-	local workspace = get_current_workspace()
-	workspace.task = lume.push(workspace.tasks, task)
-	save_workspace()
+        local workspace = get_current_workspace()
+        workspace.tasks = lume.push(workspace.tasks, task)
+        save_workspace()
 end
 
 -- Creates a new task and adds it to the workspace

--- a/lua/periscope/pickers.lua
+++ b/lua/periscope/pickers.lua
@@ -13,11 +13,10 @@ local function file_sorter()
 	return sorters.Sorter:new {
 		scoring_function = function(_, prompt, ordinal, entry)
 			-- Sort by usage
-			local last_file = model().get_current_workspace().last_file or "no_last_file"
-			print("last_file ", prompt, ordinal, entry.value.path, last_file)
-			if entry.value.path == last_file then
-				return 9999999999999
-			end
+                        local last_file = model().get_current_workspace().last_file or "no_last_file"
+                        if entry.value.path == last_file then
+                                return 9999999999999
+                        end
 			return -entry.value.usage
 		end,
 	}


### PR DESCRIPTION
## Summary
- fix boolean flag initialization in `setup`
- correct task storage field and remove debug log

## Testing
- `lua -e "assert(loadfile('lua/periscope/init.lua'))"`
- `lua -e "assert(loadfile('lua/periscope/model.lua'))"`
- `lua -e "assert(loadfile('lua/periscope/pickers.lua'))"`


------
https://chatgpt.com/codex/tasks/task_e_684e9c8faf0483218d59df3dec856334